### PR TITLE
Fix websocket ports and CORS configuration

### DIFF
--- a/backend/app/api/websocket.py
+++ b/backend/app/api/websocket.py
@@ -4,7 +4,13 @@ from ..core.database import SessionLocal
 from ..models.models import Chat, Message
 import json
 
-sio = socketio.AsyncServer(async_mode='asgi', cors_allowed_origins=['http://localhost:52501'])
+sio = socketio.AsyncServer(
+    async_mode='asgi',
+    cors_allowed_origins=[
+        'http://localhost:51692',
+        'http://localhost:55237'
+    ]
+)
 app = socketio.ASGIApp(sio)
 
 ai_service = AIService()

--- a/backend/run.py
+++ b/backend/run.py
@@ -4,7 +4,7 @@ if __name__ == "__main__":
     uvicorn.run(
         "app.main:app",
         host="0.0.0.0",
-        port=59500,
+        port=51692,
         reload=True,
         ws_ping_interval=None,
         ws_ping_timeout=None

--- a/frontend/src/services/ChatService.ts
+++ b/frontend/src/services/ChatService.ts
@@ -31,7 +31,7 @@ class ChatService {
   private errorHandlers: ((error: any) => void)[] = [];
 
   connect() {
-    this.socket = io('http://localhost:59500', {
+    this.socket = io('http://localhost:51692', {
       path: '/ws/socket.io',
       transports: ['websocket'],
     });


### PR DESCRIPTION
This PR fixes the websocket connection issues by:

- Updating backend websocket server to accept connections from allowed ports (51692 and 55237)
- Updating frontend ChatService to use port 51692
- Updating backend server port configuration
- Fixing CORS configuration to allow connections from both ports

These changes should resolve the ASGI application errors and enable proper websocket communication between frontend and backend.